### PR TITLE
Changing number of hobbies to ensure a loop is used

### DIFF
--- a/src/from-scratch.spec.js
+++ b/src/from-scratch.spec.js
@@ -132,7 +132,7 @@ describe(testSuiteName, () => {
     const person2 = {
       name: 'Jane',
       age: 43,
-      hobbies: ['jogging', 'chess', 'swimming'],
+      hobbies: ['jogging', 'chess'],
     };
 
     listHobbies(person1);
@@ -147,7 +147,6 @@ describe(testSuiteName, () => {
     expect(log.mock.calls).toEqual([
       ['Jane likes jogging.'],
       ['Jane likes chess.'],
-      ['Jane likes swimming.'],
     ]);
     jest.clearAllMocks();
 


### PR DESCRIPTION
This code passes the current tests. 

```js
const listHobbies = (person) => {
  console.log(`${person.name} likes ${person.hobbies[0]}.`)
  console.log(`${person.name} likes ${person.hobbies[1]}.`)
  console.log(`${person.name} likes ${person.hobbies[2]}.`)
};
```